### PR TITLE
Just found this point where the form was being recreated for no real reason. 

### DIFF
--- a/code/controllers/EventRegisterController.php
+++ b/code/controllers/EventRegisterController.php
@@ -42,7 +42,7 @@ class EventRegisterController extends Page_Controller {
 		}
 
 		$form   = $this->RegisterForm();
-		$expiry = $this->RegisterForm()->getExpiryDateTime();
+		$expiry = $form->getExpiryDateTime();
 
 		if ($expiry && $expiry->InPast()) {
 			$form->getSession()->Registration()->delete();


### PR DESCRIPTION
BUGFIX: Reuse the  variable to prevent creation of a completely new form object when not needed
