### PR TITLE
Change dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
 		"silverstripe/cms": ">=3.1",
 		"silverstripe/framework": ">=3.1",
 		"silverstripe/multiform": "dev-master",
-		"unclecheese/event-calendar": "dev-master"
+		"unclecheese/eventcalendar": "dev-master"
 	},
 	"suggest": {
 		"silverstripe/queuedjobs": "Allows sending out event reminder emails"


### PR DESCRIPTION
ajshort/silverstripe-eventmanagement dev-master requires unclecheese/event-calendar dev-master -> no matching package found.

The current event calendar is unclecheese/eventcalendar
