### PR TITLE
[User Deprecated] Config static EventRegisterFormSession::$has_one must ...

### DIFF
--- a/code/forms/EventRegisterFormSession.php
+++ b/code/forms/EventRegisterFormSession.php
@@ -8,7 +8,7 @@
  */
 class EventRegisterFormSession extends MultiFormSession {
 
-	public static $has_one = array(
+	private static $has_one = array(
 		'Registration' => 'EventRegistration'
 	);
 


### PR DESCRIPTION
...be marked as private.

[User Deprecated] Config static EventRegisterFormSession::$has_one must be marked as private. Line 11
