### PR TITLE
Registrable Event CMS fields improvements

### DIFF
--- a/code/pages/RegistrableEvent.php
+++ b/code/pages/RegistrableEvent.php
@@ -49,18 +49,7 @@ class RegistrableEvent extends CalendarEvent {
 	public function getCMSFields() {
 		$fields = parent::getCMSFields();
 
-		$title = $fields->dataFieldByName('Title');
-		$content = $fields->dataFieldByName('Content');
-
-		$fields->removeByName('Title', true);
-		$fields->removeByName('Content', true);
-
-		$fields->addFieldsToTab('Root.Main', array(
-			new ToggleCompositeField(
-				'PageContent',
-				_t('EventRegistration.PAGE_CONTENT', 'Page Content'),
-				array($title, $content)
-			),
+		$fields->insertAfter(
 			new ToggleCompositeField(
 				'AfterRegistrationContent',
 				_t('EventRegistration.AFTER_REG_CONTENT', 'After Registration Content'),
@@ -69,6 +58,10 @@ class RegistrableEvent extends CalendarEvent {
 					new HtmlEditorField('AfterRegContent', _t('EventRegistration.CONTENT', 'Content'))
 				)
 			),
+			'Content'
+		);
+
+		$fields->insertAfter(
 			new ToggleCompositeField(
 				'AfterUnRegistrationContent',
 				_t('EventRegistration.AFTER_UNREG_CONTENT', 'After Un-Registration Content'),
@@ -76,8 +69,9 @@ class RegistrableEvent extends CalendarEvent {
 					new TextField('AfterUnregTitle', _t('EventRegistration.TITLE', 'Title')),
 					new HtmlEditorField('AfterUnregContent', _t('EventRegistration.CONTENT', 'Content'))
 				)
-			)
-		));
+			),
+			'AfterRegistrationContent'
+		);
 
 		if ($this->RegEmailConfirm) {
 			$fields->addFieldToTab('Root.Main', new ToggleCompositeField(
@@ -131,22 +125,27 @@ class RegistrableEvent extends CalendarEvent {
 			$fields->addFieldToTab('Root.Tickets', $generator);
 		}
 
+		$regGridFieldConfig = GridFieldConfig_Base::create()
+		->removeComponentsByType('GridFieldAddNewButton')
+		->removeComponentsByType('GridFieldDeleteAction')
+		->addComponents(
+			new GridFieldButtonRow('after'),
+			new GridFieldPrintButton('buttons-after-left'),
+			new GridFieldExportButton('buttons-after-left')
+		);
+
 		$fields->addFieldsToTab('Root.Registrations', array(
 			new GridField(
 				'Registrations',
 				_t('EventManagement.REGISTRATIONS', 'Registrations'),
-				$this->DateTimes()->relation('Registrations')->filter('Status', 'Valid')
+				$this->DateTimes()->relation('Registrations')->filter('Status', 'Valid'),
+				$regGridFieldConfig
 			),
-			new ToggleCompositeField(
+			new GridField(
 				'CanceledRegistrations',
-				_t('EventManagement.CANCELED_REGISTRATIONS', 'Canceled Registrations'),
-				array(
-					new GridField(
-						'CanceledRegistrations',
-						'',
-						$this->DateTimes()->relation('Registrations')->filter('Status', 'Canceled')
-					)
-				)
+				_t('EventManagement.CANCELLATIONS', 'Cancellations'),
+				$this->DateTimes()->relation('Registrations')->filter('Status', 'Canceled'),
+				$regGridFieldConfig
 			)
 		));
 

--- a/templates/EventSendInvitationsButton.ss
+++ b/templates/EventSendInvitationsButton.ss
@@ -1,0 +1,3 @@
+<a href="$Link" class="action action-detail ss-ui-button ui-button ui-widget ui-state-default ui-corner-all send-invitations">
+$Title
+</a>


### PR DESCRIPTION

Squashed commits:
[3297e15] Moved cancelled registrations out of toggle field
Cancelled registrations weren’t showing while inside the toggle field,
plus being able to see both gridfields together makes management easier.
[561724c] Rearranged fields on Main tab
Put the title field back where it belongs.
Moved the Metadata fields below the event specific fields
[9b22d41] Added Send Invitation button to templates

Cherry picked some commits from @tardinha 's master branch

Included missing EventSendInvitationsButton, although it doesn't do anything.