### PR TITLE
Replaced deprecated TableListField with GridField in EventRegistration

### DIFF
--- a/code/dataobjects/EventRegistration.php
+++ b/code/dataobjects/EventRegistration.php
@@ -51,15 +51,19 @@ class EventRegistration extends DataObject {
 		$fields->removeByName('Token');
 		$fields->removeByName('TimeID');
 
-		$fields->addFieldToTab('Root.Tickets', $tickets = new TableListField(
+		$config = GridFieldConfig_RelationEditor::create();
+		$config->getComponentByType('GridFieldDataColumns')->setDisplayFields(array(
+			'Title'        => 'Ticket Title',
+			'PriceSummary' => 'Price',
+			'Quantity'     => 'Quantity'
+		));
+		$ticketsGridField = GridField::create(
 			'Tickets',
 			'EventTicket',
-			array(
-				'Title'        => 'Ticket Title',
-				'PriceSummary' => 'Price',
-				'Quantity'     => 'Quantity'
-			)));
-		$tickets->setCustomSourceItems($this->Tickets());
+			$this->Tickets(),
+			$config
+		);
+		$fields->addFieldToTab('Root.Tickets', $ticketsGridField);
 
 		if (class_exists('Payment')) {
 			$fields->addFieldToTab('Root.Tickets', new ReadonlyField(


### PR DESCRIPTION
TableListField has been deprecated in favour of GridField

2012-03-12 [2d151b8](https://github.com/silverstripe/sapphire/commit/2d151b8) Deprecated TableListField and ComplexTableField, use GridField instead (Ingo Schommer)