### PR TITLE
Fix addWhere calls creating wrong sql queries

### DIFF
--- a/code/dataobjects/EventTicket.php
+++ b/code/dataobjects/EventTicket.php
@@ -203,12 +203,12 @@ class EventTicket extends DataObject {
 		$booked->addLeftJoin('EventRegistration', '"EventRegistration"."ID" = "EventRegistrationID"');
 
 		if ($excludeId) {
-			$booked->addWhere('"EventRegistration"."ID"', '<>', $excludeId);
+			$booked->addWhere('"EventRegistration"."ID" <>' . (int)$excludeId);
 		}
 
-		$booked->addWhere('"Status"', '<>', 'Canceled');
-		$booked->addWhere('"EventTicketID"', $this->ID);
-		$booked->addWhere('"EventRegistration"."TimeID"', $time->ID);
+		$booked->addWhere('"Status" <> \'Canceled\'');
+		$booked->addWhere('"EventTicketID" = ' . (int)$this->ID);
+		$booked->addWhere('"EventRegistration"."TimeID" =' . (int)$time->ID);
 
 		$booked = $booked->execute()->value();
 

--- a/code/dataobjects/RegistrableDateTime.php
+++ b/code/dataobjects/RegistrableDateTime.php
@@ -233,11 +233,11 @@ class RegistrableDateTime extends CalendarDateTime {
 		$taken->addLeftJoin('EventRegistration', '"EventRegistration"."ID" = "EventRegistrationID"');
 
 		if ($excludeId) {
-			$taken->addWhere('"EventRegistration"."ID"', '<>', $excludeId);
+			$taken->addWhere('"EventRegistration"."ID" <>'. (int)$excludeId);
 		}
 
-		$taken->addWhere('"Status"', '<>', 'Canceled');
-		$taken->addWhere('"EventRegistration"."TimeID"', $this->ID);
+		$taken->addWhere('"Status" <> \'Canceled\'');
+		$taken->addWhere('"EventRegistration"."TimeID" ='. (int)$this->ID);
 		$taken = $taken->execute()->value();
 
 		return ($this->Capacity >= $taken) ? $this->Capacity - $taken : false;


### PR DESCRIPTION
`SQLQuery::addWhere()` no longer accepts multiple args and instead expects a single valid where clause to be added. The current code produces a query like the following:
```sql
SELECT SUM(Quantity)
FROM EventRegistration_Tickets
LEFT JOIN EventRegistration ON EventRegistration.ID = EventRegistrationID
WHERE (Status)
AND (EventTicketID)
AND (EventRegistration.TimeID)
```

Which while valid actually gets any registered ticket not just the current event.
With the changes we get a query something like this:

```sql
SELECT SUM(Quantity)
FROM EventRegistration_Tickets
LEFT JOIN EventRegistration ON EventRegistration.ID = EventRegistrationID
WHERE (Status <> Canceled)
AND (EventTicketID = 11)
AND (EventRegistration.TimeID =13)
```

Which returns the expected ticket numbers.