### PR TITLE
Fix EventRegistration not having permission checks

### DIFF
--- a/code/dataobjects/EventRegistration.php
+++ b/code/dataobjects/EventRegistration.php
@@ -109,4 +109,24 @@ class EventRegistration extends DataObject {
 		);
 	}
 
+	public function canView($member = null) {
+		return $this->Time()->canView($member)
+			 && Permission::check("CMS_ACCESS_CMSMain", $member);
+	}
+
+	public function canEdit($member = null) {
+		return $this->Time()->canEdit($member)
+			 && Permission::check("CMS_ACCESS_CMSMain", $member);
+	}
+
+	public function canDelete($member = null) {
+		return $this->Time()->canDelete($member)
+			 && Permission::check("CMS_ACCESS_CMSMain", $member);
+	}
+
+	public function canCreate($member = null) {
+		return $this->Time()->canCreate($member)
+			 && Permission::check("CMS_ACCESS_CMSMain", $member);
+	}
+
 }


### PR DESCRIPTION
Currently CMS users with limited access (i.e Content Authors) can create events but are unable to view the registrations to the events, even if they have created them.